### PR TITLE
Performance things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ before_install:
   - npm config set strict-ssl false
 
 language: node_js
+
+node_js: 0.11.16

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,5 @@
+before_install:
+# https://github.com/npm/npm/issues/20203
+  - npm config set strict-ssl false
+
 language: node_js

--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ connection.query(SQL`select ${fields} from scores where time > current_date`);
 connection.query(SQL`select ${fields} from scores where score > ${minScore}`);
 ```
 
+Values are reused within the query if the piece is reused.
+
+```javascript
+var ids = SQL`${[1, 2, 3]}`;
+var query = SQL`
+  select name from a where id = any(${ids})
+  union all
+  select name from b where id = any(${ids})
+`;
+query.text;   // 'select ... where id = any($1) union all select ... where id = any($1)'
+query.values; // [[1, 2, 3]]
+```
+
 There's a `.join` function analog to `Array.prototype.join` to join together literals.
 
 ```javascript

--- a/src.js
+++ b/src.js
@@ -3,25 +3,48 @@ class SqlLiteral {
     this._parts = parts;
     this._values = values;
   }
-  getText(starting=1) {
-    return this._parts.reduce((prev, curr, i) => {
-      var child = this._values[i-1];
-      var mid;
-      if (child instanceof SqlLiteral) {
-        mid = child.getText(starting);
-        starting += child.values.length;
+
+  _resolveText(starting, descendants) {
+    if (!descendants.has(this)) {
+      const text = this._parts.reduce((prev, curr, i) => {
+        var child = this._values[i-1];
+        var mid;
+        if (child instanceof SqlLiteral) {
+          starting = child._resolveText(starting, descendants);
+          mid = descendants.get(child);
+        }
+        else mid = "$" + (starting++);
+        return prev+mid+curr;
+      });
+      descendants.set(this, text);
+    }
+    return starting;
+  }
+
+  _resolveValues(descendants, values) {
+    if (!descendants.has(this)) {
+      for (const child of this._values) {
+        if (child instanceof SqlLiteral) {
+          child._resolveValues(descendants, values);
+        } else {
+          values.push(child);
+        }
       }
-      else mid = "$" + (starting++);
-      return prev+mid+curr;
-    });
+      descendants.add(this);
+    }
   }
+
   get text() {
-    return this.getText();
+    const descendants = new Map();
+    this._resolveText(1, descendants);
+    return descendants.get(this);
   }
+
   get values() {
-    return this._values.reduce((prev, curr) => prev.concat(
-      curr instanceof SqlLiteral ? curr.values : [curr]
-    ), []);
+    const descendants = new Set();
+    const values = [];
+    this._resolveValues(descendants, values);
+    return values;
   }
 }
 

--- a/test-src.js
+++ b/test-src.js
@@ -35,4 +35,17 @@ describe("pg-template-tag", function() {
     assert.equal(literal.text, "$1,$2,$3");
     assert.deepEqual(literal.values, [1, 'hello', [1, 2, 3]]);
   });
+
+  it("reuses values for reused child parts", function () {
+    var child = SQL`${0}`;
+    var literal = SQL`${child} ${child} ${child}`;
+    assert.equal(literal.text, '$1 $1 $1');
+    assert.deepEqual(literal.values, [0]);
+  });
+
+  it("does not reuse values if child parts aren't reused", function() {
+    var literal = SQL`${0} ${0} ${0}`;
+    assert.equal(literal.text, '$1 $2 $3');
+    assert.deepEqual(literal.values, [0, 0, 0]);
+  });
 });


### PR DESCRIPTION
* Avoid redundant .values calculation
* Cache .text and .values
* Deduplicate parameter values (#5)

I don't expect these to be very significant unless there are deep trees, or a large array is used as a parameter multiple times.